### PR TITLE
Add search form to App Header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import Article from './pages/Article';
 import CategoryFeed from './pages/CategoryFeed';
 import VideoTab from './pages/VideoTab';
 import SinglePlaylist from './pages/SinglePlaylist';
+import Search from './pages/Search';
 
 setupIonicReact();
 
@@ -50,6 +51,9 @@ const App: React.FC = () => (
           <Switch>
             <Route exact path="/home">
               <Home />
+            </Route>
+            <Route exact path="/search">
+              <Search />
             </Route>
             <Route path="/category/:id/:name">
               <CategoryFeed />

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,24 +1,44 @@
-import { IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton } from "@ionic/react"
+import { IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonIcon, IonButton } from "@ionic/react"
+import { ellipsisVerticalOutline } from "ionicons/icons"
 import PropTypes from "prop-types"
+import HeaderPopover from "./HeaderPopover"
+import SearchForm from "./SearchForm"
 
 const AppHeader = (props: any) => {
 
   return (
-      <IonHeader style={{ backgroundColor: '#ad0000', color: '#ffffff' }}>
-        <IonToolbar color='#33cc66'>
-          {
-            props.backButton ?
-              <IonButtons slot="start">
-                <IonBackButton defaultHref={"/home"} />
-              </IonButtons>
+    <IonHeader style={{ backgroundColor: '#ad0000', color: '#ffffff' }}>
+      <IonToolbar color='#33cc66'>
+        {
+          props.backButton ?
+            <IonButtons slot="start">
+              <IonBackButton defaultHref={"/home"} />
+            </IonButtons>
             : null
-          }
-          <IonTitle>
-            {props.categoryName !== '' ? props.categoryName + ' ' + props.title : props.title}
-          </IonTitle>
-        </IonToolbar>
-          {props.segment !== '' ? props.segment : null}
-      </IonHeader>
+        }
+
+        {
+          props.title !== "Search" ?
+            <IonTitle>
+              {props.categoryName !== '' ? props.categoryName + ' ' + props.title : props.title}
+            </IonTitle>
+            : null
+        }
+    
+        <IonButtons slot="primary" id="search">
+          <IonButton fill="solid" color="secondary">
+            <IonIcon icon={ellipsisVerticalOutline} slot="end" />
+          </IonButton>
+        </IonButtons>
+
+        {
+          props.title === "Search" ? <SearchForm /> : null
+        }
+
+        <HeaderPopover />
+      </IonToolbar>
+      {props.segment !== '' ? props.segment : null}
+    </IonHeader>
   )
 }
 

--- a/src/components/HeaderPopover.tsx
+++ b/src/components/HeaderPopover.tsx
@@ -1,0 +1,16 @@
+import { IonPopover, IonContent, IonList, IonItem } from "@ionic/react";
+import React from "react";
+
+const HeaderPopover: React.FC = () => { 
+  return (
+    <IonPopover trigger="search" triggerAction="click">
+      <IonContent class="ion-padding">
+        <IonList>
+          <IonItem button={true} detail={false} href="/search">Search</IonItem>
+        </IonList>
+      </IonContent>
+    </IonPopover>
+  );
+}
+
+export default HeaderPopover;

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,0 +1,12 @@
+import { IonSearchbar } from "@ionic/react";
+import React, { useState } from "react";
+import './css-modules/Search.css';
+
+const SearchForm: React.FC = (props: object) => {
+  const [searchText, setSearchText] = useState('');
+  return (
+    <IonSearchbar id="search-form" value={searchText} onIonChange={e => setSearchText(e.detail.value!)}></IonSearchbar>
+  )
+}
+
+export default SearchForm;

--- a/src/components/css-modules/Search.css
+++ b/src/components/css-modules/Search.css
@@ -1,0 +1,5 @@
+#search-form > .searchbar-input-container > input {
+  border: 0;
+  box-shadow: none;
+  border-radius: 20px;
+}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,17 @@
+import { IonContent, IonPage } from '@ionic/react';
+import React from 'react';
+import AppHeader from '../components/AppHeader';
+
+const Search: React.FC = (prop : object) => {
+
+  return (
+    <IonPage>
+      <AppHeader title="Search" backButton={true}/>
+      <IonContent fullscreen>
+
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Search;


### PR DESCRIPTION
### Description:
- In this feature, I added a search 🔍  form to the app header component. The form only shows on the search page even though the App header is used across pages. ✅ 

- I added a popover menu for the more icon in the header which displays the search option ✅ 



|![image](https://user-images.githubusercontent.com/5249414/177825144-3053f219-4cc8-4c42-a26c-df350b21876d.png) | ![image](https://user-images.githubusercontent.com/5249414/177825064-8d7afa92-ed88-4780-8ccc-7a3106928123.png) |
| ------------- | ------------- |


